### PR TITLE
Only include Account Holder name if verified

### DIFF
--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -89,7 +89,11 @@ const patchApplications = ({ getDbInstance }) => async ({
       return {
         record_type: application.record_type,
         unique_payment_reference: application.unique_payment_reference,
-        account_holder: application.account_holder,
+        account_holder:
+          validations.businessBankAccount === undefined ||
+          validations.businessBankAccount.accountHolder === false
+            ? ''
+            : application.account_holder,
         contact_address_first_line: application.contact_address_first_line,
         contact_address_second_line: application.contact_address_second_line,
         contact_address_third_line: application.contact_address_third_line,

--- a/lib/usecases/patchApplications.test.js
+++ b/lib/usecases/patchApplications.test.js
@@ -154,6 +154,32 @@ describe('patchApplications', () => {
     expect(csvString).toEqual(expect.not.stringContaining(',sort code1,'));
   });
 
+  test('bank account holder is included if validated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountHolder: true },
+    });
+
+    const { csvString } = await patchApplications(container)({
+      author: 'foo',
+      grant_type: 'lrsg_open',
+    });
+
+    expect(csvString).toEqual(expect.stringContaining(',accountholder1,'));
+  });
+
+  test('bank account holder is blank if not validated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountHolder: false },
+    });
+
+    const { csvString } = await patchApplications(container)({
+      author: 'foo',
+      grant_type: 'lrsg_open',
+    });
+
+    expect(csvString).toEqual(expect.not.stringContaining(',accountholder1,'));
+  });
+
   test('exports correct grant and amount for grant_type', async () => {
     const { container } = createContainerAndDatabaseSpy(1);
 


### PR DESCRIPTION
This removes the account holder name if the check box in the admin area
has not been checked (i.e. the information confirmed correct)

Co-authored-by: Yusuf <yusuf@madetech.com>
