### PR TITLE
Round 2 Grants

### DIFF
--- a/components/ApplicationGrantAmountSelector/ApplicationGrantAmountSelector.jsx
+++ b/components/ApplicationGrantAmountSelector/ApplicationGrantAmountSelector.jsx
@@ -57,6 +57,7 @@ const ApplicationGrantAmountSelector = ({
   options,
   storeAs,
   onChange,
+  tag,
 }) => {
   const [error, setError] = useState();
   const [successMessage, setSuccessMessage] = useState(false);
@@ -82,6 +83,7 @@ const ApplicationGrantAmountSelector = ({
         value={value}
         error={error && { message: error }}
         isUnselectable={false}
+        tag={tag}
       />
       {customValueVisible && (
         <TextInput

--- a/components/ApplicationGrantAmountSelector/ApplicationGrantAmountSelector.jsx
+++ b/components/ApplicationGrantAmountSelector/ApplicationGrantAmountSelector.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { Button, Select, TextInput } from 'components/Form';
 import { patchApplication } from 'utils/api/applications';
-import { GRANT_AMOUNT, FREE_TEXT } from '../../lib/dbMapping';
+import { FREE_TEXT } from '../../lib/dbMapping';
 
 export const handleOnChange = (
   setError,
@@ -61,10 +61,10 @@ const ApplicationGrantAmountSelector = ({
   const [error, setError] = useState();
   const [successMessage, setSuccessMessage] = useState(false);
   const [value, setValue] = useState(
-    GRANT_AMOUNT.includes(grantAmountAwarded) ? grantAmountAwarded : 'Other'
+    options.includes(grantAmountAwarded) ? grantAmountAwarded : 'Other'
   );
   const [customValueVisible, setCustomValueVisible] = useState(
-    !GRANT_AMOUNT.includes(grantAmountAwarded)
+    !options.includes(grantAmountAwarded)
   );
   const [customValue, setCustomValue] = useState(grantAmountAwarded);
   return (

--- a/components/ApplicationStateSelector/ApplicationStateSelector.jsx
+++ b/components/ApplicationStateSelector/ApplicationStateSelector.jsx
@@ -26,7 +26,7 @@ const ApplicationStateSelector = ({ status, onChange, applicationId }) => {
       <Select
         name="state"
         label="State"
-        options={APPLICATION_STATE}
+        options={Object.values(APPLICATION_STATE)}
         onChange={handleOnChange}
         value={value}
         error={error && { message: error }}

--- a/components/ApplicationView/ApplicationView.jsx
+++ b/components/ApplicationView/ApplicationView.jsx
@@ -16,6 +16,7 @@ const ApplicationView = ({ applicationId }) => {
   const [error, setError] = useState(false);
   const [status, setStatus] = useState();
   const [grantAmountAwarded, setGrantAwardedAmount] = useState();
+  const [grantAmountAwardedRound2, setGrantAwardedAmountRound2] = useState();
   const [validationRecap, setValidationRecap] = useState();
   const { register, watch, reset } = useForm({ defaultValues: {} });
   const watcher = watch({ nest: true });
@@ -140,13 +141,13 @@ const ApplicationView = ({ applicationId }) => {
                 />
 
                 <ApplicationGrantAmountSelector
-                  storeAs="grantAmountAwarded"
+                  storeAs="grantAmountAwardedRound2"
                   name="arg-round-2"
                   label="Round 2 Grant Amount"
                   options={GRANT_AMOUNT_ROUND_2}
                   grantAmountAwarded={data.grantAmountAwardedRound2}
                   applicationId={applicationId}
-                  onChange={setGrantAwardedAmount}
+                  onChange={setGrantAwardedAmountRound2}
                 />
               </div>
             </div>
@@ -179,6 +180,7 @@ const ApplicationView = ({ applicationId }) => {
             applicationId={applicationId}
             status={status}
             grantAmountAwarded={grantAmountAwarded}
+            grantAmountAwardedRound2={grantAmountAwardedRound2}
           />
         </>
       )}

--- a/components/ApplicationView/ApplicationView.jsx
+++ b/components/ApplicationView/ApplicationView.jsx
@@ -138,6 +138,7 @@ const ApplicationView = ({ applicationId }) => {
                   grantAmountAwarded={data.grantAmountAwarded}
                   applicationId={applicationId}
                   onChange={setGrantAwardedAmount}
+                  tag={data.round1PaymentExported ? 'EXPORTED' : ''}
                 />
 
                 <ApplicationGrantAmountSelector
@@ -148,6 +149,7 @@ const ApplicationView = ({ applicationId }) => {
                   grantAmountAwarded={data.grantAmountAwardedRound2}
                   applicationId={applicationId}
                   onChange={setGrantAwardedAmountRound2}
+                  tag={data.round2PaymentExported ? 'EXPORTED' : ''}
                 />
               </div>
             </div>

--- a/components/ApplicationView/ApplicationView.jsx
+++ b/components/ApplicationView/ApplicationView.jsx
@@ -144,7 +144,7 @@ const ApplicationView = ({ applicationId }) => {
                   name="arg-round-2"
                   label="Round 2 Grant Amount"
                   options={GRANT_AMOUNT_ROUND_2}
-                  grantAmountAwarded={data.grantAmountAwarded}
+                  grantAmountAwarded={data.grantAmountAwardedRound2}
                   applicationId={applicationId}
                   onChange={setGrantAwardedAmount}
                 />

--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -127,6 +127,7 @@ const ApplicationsList = ({
   );
   const handleCsvDownload = async (e) => {
     try {
+      setError(null);
       const round = e.target.getAttribute('round');
       const csv = await patchApplications({ round });
       window.open(encodeURI(`data:text/csv;charset=utf-8,${csv}`));

--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -139,7 +139,7 @@ const ApplicationsList = ({
   return !error ? (
     <>
       <BasicSelect
-        options={APPLICATION_STATE}
+        options={Object.values(APPLICATION_STATE)}
         label="Filter by Status:"
         value={filters.status}
         onChange={(status) => setValues({ status })}

--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -125,10 +125,10 @@ const ApplicationsList = ({
     },
     []
   );
-  const handleCsvDownload = async () => {
+  const handleCsvDownload = async (e) => {
     try {
-      setError(null);
-      const csv = await patchApplications();
+      const round = e.target.getAttribute('round');
+      const csv = await patchApplications({ round });
       window.open(encodeURI(`data:text/csv;charset=utf-8,${csv}`));
     } catch (e) {
       e.response.status = 400;
@@ -210,14 +210,28 @@ const ApplicationsList = ({
           {!canDownloadCsvs &&
             `These downloads are disabled as you are not part of the '${csvDownloadGroup}' user group`}
         </p>
-        <button
-          className="govuk-button govuk-button--secondary govuk-!-margin-right-1"
-          data-module="govuk-button"
-          onClick={handleCsvDownload}
-          {...csvExportProps}
-        >
-          Export Panel Approved Payments
-        </button>
+        <div>
+          <button
+            className="govuk-button govuk-button--secondary govuk-!-margin-right-1"
+            data-module="govuk-button"
+            round={1}
+            onClick={handleCsvDownload}
+            {...csvExportProps}
+          >
+            Export Panel Approved Payments (Round 1)
+          </button>
+        </div>
+        <div>
+          <button
+            className="govuk-button govuk-button--secondary govuk-!-margin-right-1"
+            data-module="govuk-button"
+            round={2}
+            onClick={handleCsvDownload}
+            {...csvExportProps}
+          >
+            Export Panel Approved Payments (Round 2)
+          </button>
+        </div>
       </div>
     </>
   ) : (

--- a/components/Comments/Comments.jsx
+++ b/components/Comments/Comments.jsx
@@ -8,7 +8,12 @@ import { TextArea, Button } from 'components/Form';
 
 import styles from './Comments.module.css';
 
-const Comments = ({ applicationId, status, grantAmountAwarded }) => {
+const Comments = ({
+  applicationId,
+  status,
+  grantAmountAwarded,
+  grantAmountAwardedRound2,
+}) => {
   const [data, setData] = useState();
   const [error, setError] = useState();
   const { register, errors, handleSubmit, reset } = useForm();
@@ -37,7 +42,7 @@ const Comments = ({ applicationId, status, grantAmountAwarded }) => {
   });
   useEffect(() => {
     fetchData();
-  }, [applicationId, status, grantAmountAwarded]);
+  }, [applicationId, status, grantAmountAwarded, grantAmountAwardedRound2]);
   if (!applicationId) {
     return null;
   }
@@ -75,6 +80,7 @@ Comments.propTypes = {
   applicationId: PropTypes.string.isRequired,
   status: PropTypes.string,
   grantAmountAwarded: PropTypes.string,
+  grantAmountAwardedRound2: PropTypes.string,
 };
 
 export default Comments;

--- a/db/migrations/20210409133435-add-grant-amount-awarded-round-2-column.js
+++ b/db/migrations/20210409133435-add-grant-amount-awarded-round-2-column.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210409133435-add-grant-amount-awarded-round-2-column-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210409133435-add-grant-amount-awarded-round-2-column-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db/migrations/20210412102148-add-payment-exported.js
+++ b/db/migrations/20210412102148-add-payment-exported.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210412102148-add-payment-exported-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210412102148-add-payment-exported-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db/migrations/20210412105049-remove-exported-for-payment-state.js
+++ b/db/migrations/20210412105049-remove-exported-for-payment-state.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210412105049-remove-exported-for-payment-state-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210412105049-remove-exported-for-payment-state-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-down.sql
+++ b/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-down.sql
@@ -1,0 +1,6 @@
+UPDATE application_assessment
+SET grant_amount_awarded=grant_amount_awarded_round_2
+WHERE grant_amount_awarded_round_2 <> '0.00';
+
+ALTER TABLE application_assessment
+DROP grant_amount_awarded_round_2;

--- a/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-up.sql
+++ b/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE application_assessment
+ADD grant_amount_awarded_round_2 numeric(12,2);
+
+ALTER TABLE application_assessment
+ADD date_time_recorded_temp timestamp;
+
+UPDATE application_assessment
+SET date_time_recorded_temp=grant_application.date_time_recorded
+FROM grant_application
+WHERE application_assessment.grant_application_id = grant_application.id;
+
+UPDATE application_assessment
+SET grant_amount_awarded_round_2=grant_amount_awarded, grant_amount_awarded='0.00'
+WHERE date_time_recorded_temp >= '2021-01-09';
+
+UPDATE application_assessment
+SET grant_amount_awarded_round_2='0.00'
+WHERE grant_amount_awarded_round_2 IS NULL;
+
+ALTER TABLE application_assessment
+DROP date_time_recorded_temp;

--- a/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-up.sql
+++ b/db/migrations/sqls/20210409133435-add-grant-amount-awarded-round-2-column-up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE application_assessment
-ADD grant_amount_awarded_round_2 numeric(12,2);
+ADD grant_amount_awarded_round_2 numeric(12,2) DEFAULT 0;
 
 ALTER TABLE application_assessment
 ADD date_time_recorded_temp timestamp;

--- a/db/migrations/sqls/20210412102148-add-payment-exported-down.sql
+++ b/db/migrations/sqls/20210412102148-add-payment-exported-down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE application_assessment
+DROP round_1_payment_exported;
+
+ALTER TABLE application_assessment
+DROP round_2_payment_exported;

--- a/db/migrations/sqls/20210412102148-add-payment-exported-up.sql
+++ b/db/migrations/sqls/20210412102148-add-payment-exported-up.sql
@@ -5,7 +5,9 @@ ALTER TABLE application_assessment
 ADD round_2_payment_exported boolean DEFAULT false;
 
 UPDATE application_assessment
-SET round_1_payment_exported = true;
+SET round_1_payment_exported = true
+WHERE application_state_id = 8 AND grant_amount_awarded <> 0;
 
 UPDATE application_assessment
-SET round_2_payment_exported = true;
+SET round_2_payment_exported = true
+WHERE application_state_id = 8 AND grant_amount_awarded_round_2 <> 0;

--- a/db/migrations/sqls/20210412102148-add-payment-exported-up.sql
+++ b/db/migrations/sqls/20210412102148-add-payment-exported-up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE application_assessment
+ADD round_1_payment_exported boolean DEFAULT false;
+
+ALTER TABLE application_assessment
+ADD round_2_payment_exported boolean DEFAULT false;
+
+UPDATE application_assessment
+SET round_1_payment_exported = true;
+
+UPDATE application_assessment
+SET round_2_payment_exported = true;

--- a/db/migrations/sqls/20210412105049-remove-exported-for-payment-state-down.sql
+++ b/db/migrations/sqls/20210412105049-remove-exported-for-payment-state-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/db/migrations/sqls/20210412105049-remove-exported-for-payment-state-up.sql
+++ b/db/migrations/sqls/20210412105049-remove-exported-for-payment-state-up.sql
@@ -1,0 +1,3 @@
+UPDATE application_assessment 
+SET application_state_id=2 
+WHERE application_state_id=8;

--- a/lib/dbMapping.js
+++ b/lib/dbMapping.js
@@ -77,19 +77,19 @@ export const STATE_AID_OPTION_WITH_MORE_Q = [
   'State Aid De Minimis Rule',
 ];
 
-export const APPLICATION_STATE = [
-  'Unprocessed',
-  'Processed - Approved',
-  'Processed - Rejected',
-  'Processed - Priority 2',
-  'Processed - Check Bank Details',
-  'Refer to Manager',
-  'NFI',
-  'Closed - Duplicate',
-  'Declined - Test',
-  'Processed - Requested Information',
-  'LRSG Eligible',
-];
+export const APPLICATION_STATE = {
+  1: 'Unprocessed',
+  2: 'Processed - Approved',
+  3: 'Processed - Rejected',
+  4: 'Processed - Priority 2',
+  5: 'Processed - Check Bank Details',
+  6: 'Refer to Manager',
+  7: 'NFI',
+  9: 'Closed - Duplicate',
+  10: 'Declined - Test',
+  11: 'Processed - Requested Information',
+  12: 'LRSG Eligible',
+};
 
 export const BUSINESS_CATEGORIES = [
   'Section A: Agricultural, forestry and fishing',

--- a/lib/dbMapping.js
+++ b/lib/dbMapping.js
@@ -85,7 +85,6 @@ export const APPLICATION_STATE = [
   'Processed - Check Bank Details',
   'Refer to Manager',
   'NFI',
-  'Exported for Payment',
   'Closed - Duplicate',
   'Declined - Test',
   'Processed - Requested Information',

--- a/lib/usecases/applicationDetails.js
+++ b/lib/usecases/applicationDetails.js
@@ -29,6 +29,7 @@ export default async ({ clientGeneratedId }) => {
       applicationDate: new Date(application.date_time_recorded).toISOString(),
       status: APPLICATION_STATE[application.application_state_id - 1],
       grantAmountAwarded: application.grant_amount_awarded,
+      grantAmountAwardedRound2: application.grant_amount_awarded_round_2,
       eligibilityCriteria: {
         tradingInHackney: application.trading_in_hackney,
         meetsArgCriteria: application.meets_arg_criteria,
@@ -141,6 +142,7 @@ const getApplicationData = async (dbInstance, clientGeneratedId) => {
                   -- aa.grant_application_id,
                   aa.application_state_id,
                   aa.grant_amount_awarded,
+                  aa.grant_amount_awarded_round_2,
                   -- Beware validations is text of JSON
                   aa.validations,
                   -- contact

--- a/lib/usecases/applicationDetails.js
+++ b/lib/usecases/applicationDetails.js
@@ -30,6 +30,8 @@ export default async ({ clientGeneratedId }) => {
       status: APPLICATION_STATE[application.application_state_id - 1],
       grantAmountAwarded: application.grant_amount_awarded,
       grantAmountAwardedRound2: application.grant_amount_awarded_round_2,
+      round1PaymentExported: application.round_1_payment_exported,
+      round2PaymentExported: application.round_2_payment_exported,
       eligibilityCriteria: {
         tradingInHackney: application.trading_in_hackney,
         meetsArgCriteria: application.meets_arg_criteria,
@@ -143,6 +145,8 @@ const getApplicationData = async (dbInstance, clientGeneratedId) => {
                   aa.application_state_id,
                   aa.grant_amount_awarded,
                   aa.grant_amount_awarded_round_2,
+                  aa.round_1_payment_exported,
+                  aa.round_2_payment_exported,
                   -- Beware validations is text of JSON
                   aa.validations,
                   -- contact

--- a/lib/usecases/applicationDetails.js
+++ b/lib/usecases/applicationDetails.js
@@ -27,7 +27,7 @@ export default async ({ clientGeneratedId }) => {
     application: {
       clientGeneratedId,
       applicationDate: new Date(application.date_time_recorded).toISOString(),
-      status: APPLICATION_STATE[application.application_state_id - 1],
+      status: APPLICATION_STATE[application.application_state_id],
       grantAmountAwarded: application.grant_amount_awarded,
       grantAmountAwardedRound2: application.grant_amount_awarded_round_2,
       round1PaymentExported: application.round_1_payment_exported,

--- a/lib/usecases/listApplications.js
+++ b/lib/usecases/listApplications.js
@@ -171,16 +171,13 @@ const listApplications = ({ getDbInstance, getListGrantOfficers }) => async ({
     let result = [];
 
     requiredState = requiredState || '';
-    const statusIndex = APPLICATION_STATE.findIndex(
-      (status) => status === requiredState
+    const statusIndex = Object.keys(APPLICATION_STATE).find(
+      (key) => APPLICATION_STATE[key] === requiredState
     );
-
-    if (statusIndex !== -1) {
-      result.push(statusIndex + 1);
+    if (statusIndex) {
+      result.push(statusIndex);
     } else {
-      for (let x = 0; x < APPLICATION_STATE.length; x++) {
-        result.push(x + 1);
-      }
+      result = Object.keys(APPLICATION_STATE);
     }
     return result;
   }

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -206,18 +206,17 @@ describe('listApplications', () => {
       expect.anything(),
       expect.objectContaining({
         statesFilter: expect.arrayContaining([
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
+          '1',
+          '2',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '9',
+          '10',
+          '11',
+          '12',
         ]),
       })
     );
@@ -225,9 +224,9 @@ describe('listApplications', () => {
 
   test('when status is defined & found, only that status is queried', async () => {
     const { databaseSpy, container } = createContainerAndSpies(0);
-    const statusIndex = 0;
+    const statusIndex = '1';
     const desiredStatus = APPLICATION_STATE[statusIndex];
-    const expectedStatus = statusIndex + 1;
+    const expectedStatus = statusIndex;
 
     const { error } = await listApplications(container)({
       status: desiredStatus,

--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -1,17 +1,19 @@
 const ObjectsToCsv = require('objects-to-csv');
 
-const patchApplications = ({ getDbInstance }) => async ({ author }) => {
+const patchApplications = ({ getDbInstance }) => async ({ author, round }) => {
   const db = await getDbInstance();
 
+  const grant_amount_column =
+    round == 2 ? 'grant_amount_awarded_round_2' : 'grant_amount_awarded';
   const query = `
     WITH exported AS
     (
         UPDATE
             application_assessment
         SET
-            application_state_id = 8 -- Mark as Exported for Payment
+            round_${round}_payment_exported = true
         WHERE
-            application_state_id = 2 -- Processed - Approved
+            round_${round}_payment_exported = false
         RETURNING grant_application_id
     ),
     noted as
@@ -36,7 +38,7 @@ const patchApplications = ({ getDbInstance }) => async ({ author }) => {
         ba.third_line AS business_address_third_line,
         ba.ward AS business_address_fourth_line,
         ba.postcode AS business_address_postcode,
-        aa.grant_amount_awarded AS amount_to_pay,
+        aa.${grant_amount_column} AS amount_to_pay,
         aa.validations,
         'B' AS payment_type,
         bba.account_sortcode,

--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -24,7 +24,7 @@ const patchApplications = ({ getDbInstance }) => async ({ author, round }) => {
               ex.grant_application_id,
               now(),
               $(user),
-              'Application Exported for Payment'
+              'Application Exported for Payment Round ${round}'
           FROM
               exported ex
     )

--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -14,6 +14,9 @@ const patchApplications = ({ getDbInstance }) => async ({ author, round }) => {
             round_${round}_payment_exported = true
         WHERE
             round_${round}_payment_exported = false
+          AND
+            ${grant_amount_column} <> 0
+          AND application_state_id = 2
         RETURNING grant_application_id
     ),
     noted as

--- a/lib/usecases/updateApplication.js
+++ b/lib/usecases/updateApplication.js
@@ -102,10 +102,10 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
   }
 
   async function processStatus(statusString) {
-    const statusIndex = APPLICATION_STATE.findIndex(
-      (status) => status === statusString
+    const statusIndex = Object.keys(APPLICATION_STATE).find(
+      (key) => APPLICATION_STATE[key] === statusString
     );
-    if (statusIndex === -1) {
+    if (!statusIndex) {
       return createResponse(INVALID_STATUS);
     }
 
@@ -118,7 +118,7 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
       DO UPDATE
       SET application_state_id = $(statusId);`;
     await dbInstance.none(updateStatusQuery, {
-      statusId: statusIndex + 1,
+      statusId: statusIndex,
       clientGeneratedId,
     });
 

--- a/lib/usecases/updateApplication.js
+++ b/lib/usecases/updateApplication.js
@@ -143,7 +143,7 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
       dbInstance,
       grantApplicationId,
       user,
-      `Additional Restrictions Grant awarded amount updated to £${grantAmountAwarded}`
+      `Additional Restrictions Grant Round 1 awarded amount updated to £${grantAmountAwarded}`
     );
 
     return createResponse(null);

--- a/lib/usecases/updateApplication.js
+++ b/lib/usecases/updateApplication.js
@@ -26,6 +26,7 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
     'status',
     'validations',
     'grantAmountAwarded',
+    'grantAmountAwardedRound2',
   ];
   let numberOfPropertiesInRequest = 0;
   for (let [key] of Object.entries(data)) {
@@ -75,6 +76,12 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
       addHistoryEntry,
       updateGrantAmount,
       data.grantAmountAwarded
+    );
+  } else if (data.grantAmountAwardedRound2) {
+    return processGrantAmountRound2(
+      addHistoryEntry,
+      updateGrantAmountRound2,
+      data.grantAmountAwardedRound2
     );
   } else {
     return processValidations(data.validations);
@@ -142,6 +149,26 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
     return createResponse(null);
   }
 
+  async function processGrantAmountRound2(
+    recordHistoryEntry,
+    update,
+    grantAmountAwardedRound2
+  ) {
+    await updateGrantAmountRound2(
+      dbInstance,
+      grantAmountAwardedRound2,
+      clientGeneratedId
+    );
+    await recordHistoryEntry(
+      dbInstance,
+      grantApplicationId,
+      user,
+      `Additional Restrictions Grant Round 2 awarded amount updated to £${grantAmountAwardedRound2}`
+    );
+
+    return createResponse(null);
+  }
+
   async function updateGrantAmount(db, grantAmountAwarded, clientGeneratedId) {
     const updateGrantAmountQuery = `
       UPDATE application_assessment
@@ -151,6 +178,23 @@ export const updateApplication = async ({ clientGeneratedId, data, user }) => {
       AND grant_application.client_generated_id = $(clientGeneratedId);`;
     await db.none(updateGrantAmountQuery, {
       grantAmountAwarded,
+      clientGeneratedId,
+    });
+  }
+
+  async function updateGrantAmountRound2(
+    db,
+    grantAmountAwardedRound2,
+    clientGeneratedId
+  ) {
+    const updateGrantAmountQuery = `
+      UPDATE application_assessment
+      SET grant_amount_awarded_round_2 = $(grantAmountAwardedRound2)
+      FROM grant_application
+      WHERE application_assessment.grant_application_id = grant_application.id
+      AND grant_application.client_generated_id = $(clientGeneratedId);`;
+    await db.none(updateGrantAmountQuery, {
+      grantAmountAwardedRound2,
       clientGeneratedId,
     });
   }

--- a/pages/api/applications/index.js
+++ b/pages/api/applications/index.js
@@ -128,6 +128,7 @@ export default async (req, res) => {
         res.setHeader('Content-Disposition', 'filename=export.csv');
         const patchResponse = await patchApplications({
           author: getUserStringFromCookie(req.headers.cookie),
+          round: req.body.round,
         });
         res.end(patchResponse.csvString);
       } catch (error) {


### PR DESCRIPTION
**What**  
Separate round 1 and round 2 grants:
Allow to export separate CSVs:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/54268893/114525499-0f16f400-9c3e-11eb-88c9-7caff6958d8d.png">

Remove "Exported for payment" status from the Status dropdown and set EXPORTED tag when CSV for the Round is exported:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/54268893/114525553-1a6a1f80-9c3e-11eb-9d63-7cebda6233b9.png">

Allow different grant amounts to be set and stored:
<img width="806" alt="image" src="https://user-images.githubusercontent.com/54268893/114525599-23f38780-9c3e-11eb-9be7-998121acc378.png">

Update the comments:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/54268893/114525641-2ce45900-9c3e-11eb-8b4a-5629af9627f7.png">
<img width="819" alt="image" src="https://user-images.githubusercontent.com/54268893/114525748-44234680-9c3e-11eb-9a33-c51b83e9b99e.png">

**Why**  
To enable grants for 2 rounds to be applied individually.

**Anything else?**
Added 3 migration files:
1. Add a separate column to store grant amount for round 2 (separate the initial value based on the date)
2. Add 2 boolean columns to track payment exported state for both rounds
3. Replace all the "Exported for payment" states with "Processed - Approved"