### PR TITLE
Add a manual permit step to prevent auto-deployment of staging resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,16 +98,22 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies-and-test
-      - assume-role-staging:
-          context: api-assume-role-staging-context
+      - permit-deploy-staging:
+          type: approval
           requires:
             - install-dependencies-and-test
           filters:
             branches:
               only: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+            - permit-deploy-staging
+          filters:
+            branches:
+              only: master
       - build-deploy-staging:
           requires:
-            - install-dependencies-and-test
             - assume-role-staging
           filters:
             branches:
@@ -120,12 +126,10 @@ workflows:
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-            - install-dependencies-and-test
             - permit-deploy-production
           filters:
             branches:
               only: master
       - build-deploy-production:
           requires:
-            - permit-deploy-production
             - assume-role-production


### PR DESCRIPTION
# What:
 - Add a manual permit requirement to deploy staging resources.

# Why:
 - So that the dated serverless config does not destroy and needlessly downgrade staging resources due to automatic deployment after merge.
