### PR TITLE
Remove lambda specifications & prepare those lambdas to get retired.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -14,11 +14,6 @@ provider:
         - s3:GetObject
       Resource: "arn:aws:s3:::${self:custom.bucket}/*"
 
-package:
-  individually: true
-  exclude:
-    - ./**
-
 resources:
   Resources:
     additionalRestrictionsGrantSupportingDocumentsBucket:

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,53 +20,6 @@ package:
     - ./**
 
 functions:
-  additional-restrictions-grant:
-    name: ${self:service}-${self:provider.stage}
-    handler: lambda.handler
-    timeout: 20
-    package:
-      include:
-        - lambda.js
-        - next.config.js
-        - pages/**
-        - public/**
-        - build/_next/**
-        - node_modules/**
-    events:
-      - http:
-          path: api/{proxy+}
-          method: ANY
-          authorizer:
-            name: authorizer
-            type: request
-            identitySource: ''
-            resultTtlInSeconds: 0
-      - http: ANY /
-      - http: ANY /{proxy+}
-    vpc:
-      securityGroupIds:
-        - Fn::GetAtt:
-          - additionalRestrictionsGrantDbSecurityGroup
-          - GroupId
-      subnetIds: ${self:custom.subnets.${self:provider.stage}}
-    environment:
-      ENV: ${self:provider.stage}
-      HOST:
-        Fn::GetAtt:
-          - additionalRestrictionsGrantDb
-          - Endpoint.Address
-      USERNAME: ${env:MASTER_USERNAME}
-      PASSWORD: ${env:MASTER_USER_PASSWORD}
-      DATABASE: ${self:provider.dbname}
-      SUPPORTING_DOCUMENTS_BUCKET: ${self:custom.bucket}
-      URL_PREFIX: ${self:custom.aliases.${self:provider.stage}}
-      EXPIRATION_DATE: ${env:EXPIRATION_DATE}
-      HACKNEY_AUTH_URL: ${env:HACKNEY_AUTH_URL}
-      GOV_NOTIFY_API_KEY: ${env:GOV_NOTIFY_API_KEY}
-      EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID: ${env:EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID}
-      CSV_DOWNLOAD_GROUP: ${env:CSV_DOWNLOAD_GROUP}
-      NEXT_PUBLIC_EQUALITIES_GOOGLE_FORM_URL: ${env:NEXT_PUBLIC_EQUALITIES_GOOGLE_FORM_URL}
-
   authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}
     handler: authorizer.handler

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,6 @@ service: additional-restrictions-grant
 
 provider:
   name: aws
-  runtime: nodejs12.x
   region: eu-west-2
   stage: ${opt:stage}
   dbname: additionalRestrictionsGrantDb

--- a/serverless.yml
+++ b/serverless.yml
@@ -130,15 +130,4 @@ custom:
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
     production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
-  subnets:
-    staging:
-      - subnet-07e8364b
-      - subnet-723cb408
-      - subnet-48094621
-    production:
-      - subnet-034b2a03cd4955923
-      - subnet-03431a6c898502c99
-      - subnet-0f02c86bab1d62956
-  allowed-groups:
-    staging: 'Additional Restrictions Grant - Staging'
-    production: 'Additional Restrictions Grant - Admin'
+

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,18 +19,6 @@ package:
   exclude:
     - ./**
 
-functions:
-  authorizer:
-    name: ${self:service}-authorizer-${self:provider.stage}
-    handler: authorizer.handler
-    package:
-      include:
-        - authorizer/**
-        - node_modules/**
-    environment:
-      ALLOWED_GROUPS: ${self:custom.allowed-groups.${self:provider.stage}}
-      JWT_SECRET: ${ssm:hackney-jwt-secret}
-
 resources:
   Resources:
     additionalRestrictionsGrantSupportingDocumentsBucket:


### PR DESCRIPTION
# What:
 - Removed the serverless definition for unused application lambda.
 - Removed the serverless definition of the authoriser that lambda.
 - Removed lambda runtime specification.
 - Removed unused custom variables.

# Why:
 - The application has been decommissioned a long time ago.
 - We're preparing the pipeline for the deployment of deletion retention policies.
 - We want these lambdas to be destroyed once we do `sls deploy`.

# Screenshots:
 
| Staging URL | Production URL |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4850b730-4cfc-454a-86da-fa251272fdd3) | ![image](https://github.com/user-attachments/assets/bbd883d8-6123-4622-8426-8983cba17dd7) |