### PR TITLE
Remove build and test steps from the pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,8 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
-          requires:
-            - install-dependencies-and-test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,35 +19,6 @@ references:
       at: *workspace_root
 
 jobs:
-  install-dependencies-and-test:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: Install dependencies
-          command: yarn
-
-      - run:
-          name: Build the application
-          command: yarn build
-
-      - run:
-          name: Run unit tests
-          command: yarn run unit-test
-
-      - run:
-          name: Run integration tests
-          command: yarn run int-test
-
-      - run:
-          name: Run linting
-          command: yarn lint
-
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: .
-
   build-deploy-staging:
     executor: aws-cli/default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - checkout
       - run:
           name: deploy
           command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
@@ -33,6 +34,7 @@ jobs:
 
     steps:
       - *attach_workspace
+      - checkout
       - run:
           name: deploy
           command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
+          command: sudo npm i -g serverless && sls deploy --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
+          command: sudo npm i -g serverless && sls deploy --stage production
           no_output_timeout: 45m
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,18 +26,23 @@ jobs:
       - checkout
       - run:
           name: deploy
-          command: sudo npm i -g serverless && sls deploy --stage staging
+          command: sudo npm i -g serverless
+      - run:
+          name: deploy
+          command: sls deploy --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:
     executor: aws-cli/default
-
     steps:
       - *attach_workspace
       - checkout
       - run:
           name: deploy
-          command: sudo npm i -g serverless && sls deploy --stage production
+          command: sudo npm i -g serverless
+      - run:
+          name: deploy
+          command: sls deploy --stage production
           no_output_timeout: 45m
 
   assume-role-staging:


### PR DESCRIPTION
# What:
 - Remove unneeded build & test steps from the pipeline.

# Why:
 - The application is long decommissioned and is no longer going to be deployed. See PR #18 .

# Notes:
 - This PR succeeds the PR #18 in that it will trigger the lambda destruction changes.
