### PR TITLE
Cap serverless to v3 for licensing purposes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run:
           name: deploy
-          command: sudo npm i -g serverless
+          command: sudo npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage staging
@@ -39,7 +39,7 @@ jobs:
       - checkout
       - run:
           name: deploy
-          command: sudo npm i -g serverless
+          command: sudo npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage production


### PR DESCRIPTION
# What:
 - Cap serverless to major version 3.

# Why:
 - Because v4 requires a paid license.
 