### PR TITLE
Remove CloudFront distribution as there's nothing left to distribute.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -76,54 +76,8 @@ resources:
             Value: "additionalRestrictionsGrantsDb"
       DeletionPolicy: "Snapshot"
 
-    CloudFrontDistribution:
-      Type: AWS::CloudFront::Distribution
-      Properties:
-        DistributionConfig:
-          Aliases:
-            - ${self:custom.aliases.${self:provider.stage}}
-          PriceClass: PriceClass_100
-          ViewerCertificate:
-            AcmCertificateArn: ${self:custom.certificate-arn.${self:provider.stage}}
-            MinimumProtocolVersion: TLSv1.2_2018
-            SslSupportMethod: sni-only
-          DefaultCacheBehavior:
-            TargetOriginId: ${self:service}-${self:provider.stage}-custom-origin
-            ViewerProtocolPolicy: 'redirect-to-https'
-            AllowedMethods:
-              - GET
-              - HEAD
-              - OPTIONS
-              - PUT
-              - PATCH
-              - POST
-              - DELETE
-            DefaultTTL: 0
-            MaxTTL: 0
-            MinTTL: 0
-            ForwardedValues:
-              QueryString: true
-              Cookies:
-                Forward: all
-          Enabled: true
-          Origins:
-            - Id: ${self:service}-${self:provider.stage}-custom-origin
-              DomainName: ${self:custom.domain-name}
-              OriginPath: /${self:provider.stage}
-              CustomOriginConfig:
-                HTTPPort: 80
-                HTTPSPort: 443
-                OriginProtocolPolicy: https-only
-
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}
-  domain-name:
-    Fn::Join:
-      - '.'
-      - - Ref: ApiGatewayRestApi
-        - execute-api
-        - eu-west-2
-        - amazonaws.com
   aliases:
     staging: staging-additionalrestrictionsgrant.hackney.gov.uk
     production: additionalrestrictionsgrant.hackney.gov.uk


### PR DESCRIPTION
# What:
 - Removed CloudFront distribution specification from the serverless configuration.

# Why:
 - It's no longer needed because the application lambda has been removed already, so there's nothing left to distribute.
 - To resolve the "invalid serverless config" issue due to "ApiGatewayRestApi" being referenced by the CFD, but not existing.

# Notes:
 - A continuation of PR #18 .