### PR TITLE
Retire the `StagingAPIs`  environment's resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --stage staging
+          command: sls remove --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,7 +58,7 @@ resources:
         DBInstanceIdentifier: "${self:service}-db-${self:provider.stage}"
         DBInstanceClass: "db.t2.small"
         DBName: ${self:provider.dbname}
-        DeletionProtection: true
+        DeletionProtection: false
         Engine: "postgres"
         EngineVersion: "11.7"
         MasterUsername: ${env:MASTER_USERNAME}

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,7 +74,7 @@ resources:
           -
             Key: "Name"
             Value: "additionalRestrictionsGrantsDb"
-      DeletionPolicy: "Snapshot"
+      DeletionPolicy: Delete
 
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}


### PR DESCRIPTION
# What:
 - Trigger the removal of AWS `StagingAPIs` environment resources.

# Why: 
 - The environment is unused as there's not active development due to the application being long decommissioned.

# Notes:
 - See the application being decommissioned right now in screenshots within PR #18 .
 - The RDS database's snapshot was created under the name of `additional-restrictions-grant-db-staging-not-used-in-15mo-snapshot`.

# Screenshots:
| Valueless staging S3 bucket | No connections in 15 months to staging database |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/be78718b-b860-46a9-8580-06641d0c6703) | ![image](https://github.com/user-attachments/assets/d43cb951-acd6-4916-9b4e-05faebeb6540) |