### PR TITLE
Attempt to resolve the: "GroupName is only supported".

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -45,11 +45,11 @@ resources:
       Type: AWS::EC2::SecurityGroup
       Properties:
         GroupDescription: Allow internal VPC
-        SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: '5432'
-          ToPort: '5432'
-          CidrIp: 172.31.0.0/16
+        # SecurityGroupIngress:
+        # - IpProtocol: tcp
+        #   FromPort: '5432'
+        #   ToPort: '5432'
+        #   CidrIp: 172.31.0.0/16
 
     additionalRestrictionsGrantDb:
       Type: AWS::RDS::DBInstance
@@ -66,10 +66,10 @@ resources:
         MultiAZ: true
         PubliclyAccessible: false
         StorageEncrypted: true
-        VPCSecurityGroups:
-        - Fn::GetAtt:
-          - additionalRestrictionsGrantDbSecurityGroup
-          - GroupId
+        # VPCSecurityGroups:
+        # - Fn::GetAtt:
+        #   - additionalRestrictionsGrantDbSecurityGroup
+        #   - GroupId
         Tags:
           -
             Key: "Name"


### PR DESCRIPTION
# What:
 - Remove the reference to the security group within the already destroyed RDS instance.
 - Remove the ingress rules from the security group.

# Why:
 - We want to delete the stack, but are getting the following we some sort of security group related error. Curou
![image](https://github.com/user-attachments/assets/b5343849-d8d3-41bf-9827-355bbae05917)
