### PR TITLE
Deploy S3 Bucket delete-preservation and remove RDS delete-protection.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -57,11 +57,12 @@ resources:
       Properties:
         AllocatedStorage: 5
         DBInstanceIdentifier: "${self:service}-db-${self:provider.stage}"
-        DBInstanceClass: "db.t2.small"
+        DBInstanceClass: "db.t3.small"
+        CACertificateIdentifier: 'rds-ca-rsa2048-g1'
         DBName: ${self:provider.dbname}
         DeletionProtection: false
         Engine: "postgres"
-        EngineVersion: "11.7"
+        EngineVersion: "11.22"
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         MultiAZ: true
@@ -72,9 +73,12 @@ resources:
           - additionalRestrictionsGrantDbSecurityGroup
           - GroupId
         Tags:
-          -
-            Key: "Name"
+          - Key: "Name"
             Value: "additionalRestrictionsGrantsDb"
+          - Key: "STAGE"
+            Value: ${self:provider.stage}
+          - Key: "BackupPolicy"
+            Value: "Prod"
       DeletionPolicy: Delete
 
 custom:

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,7 +45,6 @@ resources:
       Type: AWS::EC2::SecurityGroup
       Properties:
         GroupDescription: Allow internal VPC
-        VpcId: vpc-076787007f8a53eaa
         SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: '5432'

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,7 @@ resources:
   Resources:
     additionalRestrictionsGrantSupportingDocumentsBucket:
         Type: AWS::S3::Bucket
+        DeletionPolicy: Retain
         Properties:
           BucketName: ${self:custom.bucket}
           PublicAccessBlockConfiguration:


### PR DESCRIPTION
# What:
 - Add 'Retain' Deletion Policy for the supporting documents S3 bucket.
 - Synced up the RDS instance serverless configuration with the cloud state.
 - Remove the staging VPC id from the security group.

# Why:
 - Once we get to deleting the Cloud Formation stack within the `ProductionAPIs` account, we want to delete all resources, but preserve the S3 bucket as there's no good to take its snapshot like you can with RDS instance.
 - Did the sync work to prevent any troubles in deploying the S3 preservation due to serverless drift.
 - The VPC id on the SG was an failed attempt to resolve a bizzare issue of CloudFormation stack failing to delete a non-existent Security Group (see screenshot) #26 .

# Notes:
 - The RDS delete-protection was changed within the config in the PR #22 , however, it is yet to be deploy to `ProductionAPIs` account.

# Screenshots:

| Trying to delete the staging stack | SG doesn't exist within that staging account |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/676b2ba1-1d31-4209-8cf2-d450d88143d6) | ![image](https://github.com/user-attachments/assets/bf29d48b-5e91-4f68-8640-4a99673362ec) |
