### PR TITLE
Modify pipeline to remove production resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
       - *attach_workspace
       - checkout
       - run:
-          name: deploy
+          name: install
           command: sudo npm i -g serverless@^3
       - run:
-          name: deploy
-          command: sls deploy --stage production
+          name: destroy
+          command: sls remove --stage production
           no_output_timeout: 45m
 
   assume-role-production:


### PR DESCRIPTION
# What:
 - Retire `ProductionAPIs` arg-business-grants CloudFormation stack resources _(except S3)_.

# Why:
 - The application has been long decommissioned _(See screenshots on PR #18 )_.

# Notes:
 - The S3 will not be destroyed & will get de'associated from the stack due to previously deployed [Retain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) policy PR #28 .
 - The RDS instance will be destroyed, but it was backed up under the snapshot name: `additional-restrictions-grant-db-production-not-connected-to-in-9mo-snapshot`.

# Screenshot:

| S3 bucket has Retain policy |
| --- |
| ![image](https://github.com/user-attachments/assets/5ccea310-e98b-4285-a372-604433a6ca7b) |